### PR TITLE
Maintain window aspect ratio in preview mode

### DIFF
--- a/windows-alt-tab@tglman.org/extension.js
+++ b/windows-alt-tab@tglman.org/extension.js
@@ -240,7 +240,7 @@ AppIcon.prototype = {
         this.actor = new St.BoxLayout({ style_class: 'alt-tab-app',
                                          vertical: true });
         this.icon = null;
-        this._iconBin = new St.Bin({ x_fill: true, y_fill: true });
+        this._iconBin = new St.Bin({ x_fill: false, y_fill: false });
 
         this.actor.add(this._iconBin, { x_fill: false, y_fill: false } );
 


### PR DESCRIPTION
When set to display the window previews, the thumbnail shouldn't be stretched to fit a 1:1 aspect ratio. It should maintain the window's aspect ratio.
